### PR TITLE
Improve launcher dependency check

### DIFF
--- a/run_soulseek_downloader.sh
+++ b/run_soulseek_downloader.sh
@@ -7,6 +7,12 @@ echo "Starting SoulseekDownloader..."
 
 # Check if Python 3 is available
 if command -v python3 &> /dev/null; then
+    # Verify that PyObjC (Cocoa) is installed
+    if ! python3 -m pip show pyobjc-framework-Cocoa > /dev/null 2>&1; then
+        echo "PyObjC (pyobjc-framework-Cocoa) is not installed."
+        echo "Please run 'pip install -r requirements.txt' and try again."
+        exit 1
+    fi
     python3 soulseek_downloader.py
 elif command -v python &> /dev/null; then
     python soulseek_downloader.py


### PR DESCRIPTION
## Summary
- add PyObjC dependency check to run_soulseek_downloader.sh

## Testing
- `bash -n run_soulseek_downloader.sh`
- `sh -n run_soulseek_downloader.sh`
- `python3 -m py_compile csv_processor.py soulseek_downloader.py`


------
https://chatgpt.com/codex/tasks/task_e_6886f848f7308325984f469aa21b02f5